### PR TITLE
Relax strategy thresholds and gate limits to allow more buys

### DIFF
--- a/internal/autoSellerService/strategy_config.go
+++ b/internal/autoSellerService/strategy_config.go
@@ -50,26 +50,26 @@ func LoadStrategyConfig() StrategyConfig {
 
 func defaultStrategyConfig() StrategyConfig {
 	cfg := StrategyConfig{}
-	cfg.Watchlist.MinScore = 0.3
+	cfg.Watchlist.MinScore = 0.25
 	cfg.Watchlist.MaxPicks = 10
 	cfg.Watchlist.NewsWeight = 0.2
 	cfg.Watchlist.VolumeWeight = 0.5
 	cfg.Watchlist.FlowWeight = 0.3
 
-	cfg.Entry.ThresholdScore = 0.55
+	cfg.Entry.ThresholdScore = 0.5
 	cfg.Entry.TechnicalWeight = 0.35
 	cfg.Entry.VolumeWeight = 0.2
 	cfg.Entry.FlowWeight = 0.2
 	cfg.Entry.MarketWeight = 0.15
 	cfg.Entry.NewsWeight = 0.1
 
-	cfg.Gates.MinTurnover = 500000000
-	cfg.Gates.MaxSpreadBps = 35
-	cfg.Gates.CooldownMinutes = 15
+	cfg.Gates.MinTurnover = 300000000
+	cfg.Gates.MaxSpreadBps = 45
+	cfg.Gates.CooldownMinutes = 10
 	cfg.Gates.MaxHoldingCount = 10
 	cfg.Gates.MaxPositionPct = 0.2
-	cfg.Gates.DailyLossLimitPct = -3
-	cfg.Gates.CrashFilterPct = -2.5
+	cfg.Gates.DailyLossLimitPct = -4
+	cfg.Gates.CrashFilterPct = -3.5
 
 	cfg.Risk.FixedStopLossPct = -1.7
 	cfg.Risk.ATRStopMultiplier = 1.2

--- a/internal/config/autoJoosik_market_data_fetcher_conf.yml
+++ b/internal/config/autoJoosik_market_data_fetcher_conf.yml
@@ -24,26 +24,26 @@ database:
 
 strategy:
   watchlist:
-    minScore: 0.30
+    minScore: 0.25
     maxPicks: 10
     newsWeight: 0.20
     volumeWeight: 0.50
     flowWeight: 0.30
   entry:
-    thresholdScore: 0.55
+    thresholdScore: 0.50
     technicalWeight: 0.35
     volumeWeight: 0.20
     flowWeight: 0.20
     marketWeight: 0.15
     newsWeight: 0.10
   gates:
-    minTurnover: 500000000
-    maxSpreadBps: 35
-    cooldownMinutes: 15
+    minTurnover: 300000000
+    maxSpreadBps: 45
+    cooldownMinutes: 10
     maxHoldingCount: 10
     maxPositionPct: 0.20
-    dailyLossLimitPct: -3.0
-    crashFilterPct: -2.5
+    dailyLossLimitPct: -4.0
+    crashFilterPct: -3.5
   risk:
     fixedStopLossPct: -1.7
     atrStopMultiplier: 1.2


### PR DESCRIPTION
### Motivation
- The buy decision pipeline was too strict and resulted in few or no purchases, so strategy thresholds and gate constraints were relaxed to increase the chance of buy signals passing.

### Description
- Lowered watchlist and entry score cutoffs and relaxed gate constraints in code and synced them to the YAML config by updating `internal/autoSellerService/strategy_config.go` and `internal/config/autoJoosik_market_data_fetcher_conf.yml`.
- Concrete parameter changes: `watchlist.minScore` 0.30 -> 0.25, `entry.thresholdScore` 0.55 -> 0.50, `gates.minTurnover` 500000000 -> 300000000, `gates.maxSpreadBps` 35 -> 45, `gates.cooldownMinutes` 15 -> 10, `gates.dailyLossLimitPct` -3.0 -> -4.0, and `gates.crashFilterPct` -2.5 -> -3.5.

### Testing
- Ran unit tests for the modified package with `go test ./internal/autoSellerService -v`, and all tests in that package passed.
- No other automated tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a382c5be488321a35fc3587c56bddd)