### PR TITLE
fix: prevent empty tb_stock_info upserts

### DIFF
--- a/internal/repository/tb_stock_info_repository.go
+++ b/internal/repository/tb_stock_info_repository.go
@@ -6,13 +6,36 @@ import (
 	"context"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"reflect"
 	"strings"
 )
+
+func hasStockInfoData(entity model.TbStockInfoEntity) bool {
+	v := reflect.ValueOf(entity)
+	t := reflect.TypeOf(entity)
+
+	for i := 0; i < v.NumField(); i++ {
+		field := t.Field(i)
+		if field.Name == "StkCd" || field.Name == "UpdatedAt" {
+			continue
+		}
+
+		if strings.TrimSpace(v.Field(i).String()) != "" {
+			return true
+		}
+	}
+
+	return false
+}
 
 func UpsertStockInfo(ctx context.Context, pool *pgxpool.Pool, entity model.TbStockInfoEntity) error {
 	entity.StkCd = strings.TrimSpace(entity.StkCd)
 	if entity.StkCd == "" {
 		logger.Warn("UpsertStockInfo :: skip empty stk_cd")
+		return nil
+	}
+	if !hasStockInfoData(entity) {
+		logger.Warn("UpsertStockInfo :: skip empty stock info payload", "stk_cd", entity.StkCd)
 		return nil
 	}
 	_, err := pool.Exec(ctx,
@@ -153,6 +176,10 @@ func UpsertStockInfoBatch(ctx context.Context, pool *pgxpool.Pool, entities []mo
 			logger.Warn("UpsertStockInfoBatch :: skip empty stk_cd")
 			continue
 		}
+		if !hasStockInfoData(entity) {
+			logger.Warn("UpsertStockInfoBatch :: skip empty stock info payload", "stk_cd", entity.StkCd)
+			continue
+		}
 		batch.Queue(`
 			INSERT INTO tb_stock_info (
 				stk_cd, stk_nm, setl_mm, fav, cap,
@@ -275,6 +302,9 @@ func UpsertStockInfoBatch(ctx context.Context, pool *pgxpool.Pool, entities []mo
 
 	for _, entity := range entities {
 		if strings.TrimSpace(entity.StkCd) == "" {
+			continue
+		}
+		if !hasStockInfoData(entity) {
 			continue
 		}
 


### PR DESCRIPTION
### Motivation
- Empty rows were being created/updated in `tb_stock_info` where only `stk_cd` (and the auto timestamp) were populated, causing meaningless records.
- The change prevents storing payloads that contain no useful stock info fields to keep the DB clean.

### Description
- Added `hasStockInfoData(entity model.TbStockInfoEntity) bool` which uses `reflect` to detect whether any field other than `StkCd` and `UpdatedAt` contains non-blank data.
- Updated `UpsertStockInfo` to skip insert/update when `hasStockInfoData` returns false and log a warning.
- Updated `UpsertStockInfoBatch` to skip queuing and executing batch entries for empty payloads and log warnings when skipping.
- Modified file: `internal/repository/tb_stock_info_repository.go`.

### Testing
- Ran `gofmt -w internal/repository/tb_stock_info_repository.go` to format the change successfully.
- Ran `go test ./...` and the test run completed successfully (packages with tests passed and other packages reported no test files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6d982d5c8321b61668b45c7f51e8)