### PR TITLE
Improve autoSellerService for more aggressive short-term entries

### DIFF
--- a/internal/autoSellerService/data_providers.go
+++ b/internal/autoSellerService/data_providers.go
@@ -3,8 +3,25 @@ package autoSellerService
 import (
 	"autoJoosik-market-data-fetcher/internal/repository"
 	"context"
+	"math"
 	"time"
 )
+
+type TradeInfoTrend struct {
+	PriceMomentum      float64
+	StrengthMomentum   float64
+	BuyPressure        float64
+	VolumeAcceleration float64
+	Composite          float64
+}
+
+type tradeTrendRow struct {
+	price    float64
+	strength float64
+	buyBid   float64
+	selBid   float64
+	qty      float64
+}
 
 type NewsProvider interface {
 	SentimentScore(ctx context.Context, stkCd string) float64
@@ -76,4 +93,103 @@ LIMIT 1
 		return 0
 	}
 	return (currentBalance - startBalance) / startBalance * 100
+}
+
+func LoadTradeInfoTrend(ctx context.Context, db repository.DB, stkCd string, limit int) (TradeInfoTrend, error) {
+	if limit < 12 {
+		limit = 12
+	}
+	rows, err := db.Query(ctx, `
+SELECT cur_prc, cntr_str, pri_buy_bid_unit, pri_sel_bid_unit, cntr_trde_qty
+FROM tb_trade_info_log
+WHERE stk_cd = $1
+ORDER BY tm DESC
+LIMIT $2
+`, stkCd, limit)
+	if err != nil {
+		return TradeInfoTrend{}, err
+	}
+	defer rows.Close()
+
+	series := make([]tradeTrendRow, 0, limit)
+	for rows.Next() {
+		var r tradeTrendRow
+		if err := rows.Scan(&r.price, &r.strength, &r.buyBid, &r.selBid, &r.qty); err != nil {
+			return TradeInfoTrend{}, err
+		}
+		series = append(series, r)
+	}
+	if err := rows.Err(); err != nil {
+		return TradeInfoTrend{}, err
+	}
+	for i, j := 0, len(series)-1; i < j; i, j = i+1, j-1 {
+		series[i], series[j] = series[j], series[i]
+	}
+
+	return summarizeTradeTrend(series), nil
+}
+
+func summarizeTradeTrend(series []tradeTrendRow) TradeInfoTrend {
+	if len(series) < 2 {
+		return TradeInfoTrend{}
+	}
+
+	head := series[:len(series)/2]
+	tail := series[len(series)/2:]
+	first := series[0].price
+	last := series[len(series)-1].price
+	priceMomentum := 0.0
+	if first > 0 {
+		priceMomentum = (last - first) / first
+	}
+	priceScore := clamp((clamp(priceMomentum, -0.02, 0.02)+0.02)/0.04, 0, 1)
+
+	headStrength := 0.0
+	tailStrength := 0.0
+	for _, r := range head {
+		headStrength += r.strength
+	}
+	for _, r := range tail {
+		tailStrength += r.strength
+	}
+	headStrength /= math.Max(float64(len(head)), 1)
+	tailStrength /= math.Max(float64(len(tail)), 1)
+	strengthDelta := tailStrength - headStrength
+	strengthScore := clamp((clamp(strengthDelta, -20, 20)+20)/40, 0, 1)
+
+	buyPressure := 0.5
+	buyTotal := 0.0
+	sellTotal := 0.0
+	for _, r := range series {
+		buyTotal += math.Max(r.buyBid, 0)
+		sellTotal += math.Max(r.selBid, 0)
+	}
+	if buyTotal+sellTotal > 0 {
+		buyPressure = buyTotal / (buyTotal + sellTotal)
+	}
+
+	headQty := 0.0
+	tailQty := 0.0
+	for _, r := range head {
+		headQty += r.qty
+	}
+	for _, r := range tail {
+		tailQty += r.qty
+	}
+	headQty /= math.Max(float64(len(head)), 1)
+	tailQty /= math.Max(float64(len(tail)), 1)
+	volRatio := 1.0
+	if headQty > 0 {
+		volRatio = tailQty / headQty
+	}
+	volumeScore := clamp((clamp(volRatio, 0.5, 2.0)-0.5)/1.5, 0, 1)
+
+	composite := clamp(priceScore*0.35+strengthScore*0.25+buyPressure*0.2+volumeScore*0.2, 0, 1)
+	return TradeInfoTrend{
+		PriceMomentum:      priceScore,
+		StrengthMomentum:   strengthScore,
+		BuyPressure:        buyPressure,
+		VolumeAcceleration: volumeScore,
+		Composite:          composite,
+	}
 }

--- a/internal/autoSellerService/decision_runner.go
+++ b/internal/autoSellerService/decision_runner.go
@@ -63,15 +63,14 @@ func DecideAndExecute(ctx context.Context, pool repository.DB) error {
 	watchPicks := make([]watchCandidate, 0)
 	for _, c := range candidates {
 		candles, _ := LoadRecentCandles(ctx, pool, c.StkCd, 60)
-		ind := BuildIndicators(candles)
 		volumeBurst := volumeBurstScore(candles)
 		flow := flowProvider.NetBuyScore(ctx, c.StkCd)
 		news := newsProvider.SentimentScore(ctx, c.StkCd)
-		score := news*cfg.Watchlist.NewsWeight + volumeBurst*cfg.Watchlist.VolumeWeight + flow*cfg.Watchlist.FlowWeight
+		trend, _ := LoadTradeInfoTrend(ctx, pool, c.StkCd, 20)
+		score := news*cfg.Watchlist.NewsWeight + volumeBurst*cfg.Watchlist.VolumeWeight + flow*cfg.Watchlist.FlowWeight + trend.Composite*cfg.Watchlist.TrendWeight
 		if score >= cfg.Watchlist.MinScore {
 			watchPicks = append(watchPicks, watchCandidate{Candidate: c, Score: score})
 		}
-		_ = ind
 	}
 	watchPicks = topWatchlist(watchPicks, cfg.Watchlist.MaxPicks)
 
@@ -80,6 +79,7 @@ func DecideAndExecute(ctx context.Context, pool repository.DB) error {
 		c := w.Candidate
 		candles, _ := LoadRecentCandles(ctx, pool, c.StkCd, 120)
 		ind := BuildIndicators(candles)
+		trend, _ := LoadTradeInfoTrend(ctx, pool, c.StkCd, 30)
 		dailyPnL := EstimateDailyPnLPercent(ctx, pool, 0)
 		entry := NewEngine()
 		entry.AddGate(SimpleGate{name: "trade_time", fn: func(e EvalContext) GateResult {
@@ -150,11 +150,15 @@ func DecideAndExecute(ctx context.Context, pool repository.DB) error {
 		entry.AddFactor(WeightedFactor{name: "news", weight: cfg.Entry.NewsWeight, factor: func(e EvalContext) float64 {
 			return e.NewsScore
 		}})
+		entry.AddFactor(WeightedFactor{name: "trade_trend", weight: cfg.Entry.TradeTrendWeight, factor: func(EvalContext) float64 {
+			return trend.Composite
+		}})
 
 		evalCtx := EvalContext{Now: time.Now(), Market: market, Candidate: c, Indicators: ind, NewsScore: newsProvider.SentimentScore(ctx, c.StkCd), FlowScore: flowProvider.NetBuyScore(ctx, c.StkCd), VolumeSignal: volumeBurstScore(candles), RecentOrderOpen: hasOpenOrderRecently(ctx, pool, c.StkCd), DailyPnL: dailyPnL, CurrentSpread: 0}
+		effectiveThreshold := adjustedEntryThreshold(cfg.Entry.ThresholdScore, trend.Composite, cfg.Entry.AggressiveThresholdOffset)
 		pass, score, reasons := entry.Evaluate(evalCtx)
-		if pass && score >= cfg.Entry.ThresholdScore {
-			buyQty := decideBuyQty(score, cfg.Entry.ThresholdScore, cfg.Sizing.MaxOrderQty)
+		if pass && score >= effectiveThreshold {
+			buyQty := decideBuyQty(score, effectiveThreshold, cfg.Sizing.MaxOrderQty)
 			logger.Info("Buy decision", "stkCd", c.StkCd, "score", score, "qty", buyQty, "reasons", strings.Join(reasons, ","))
 			if err := Buy(c.StkCd, buyQty); err != nil {
 				return err
@@ -261,4 +265,12 @@ func lastVolume(candles []OHLCV) float64 {
 		return 0
 	}
 	return candles[len(candles)-1].Volume
+}
+
+func adjustedEntryThreshold(base, trendComposite, offset float64) float64 {
+	threshold := base
+	if trendComposite >= 0.75 {
+		threshold -= offset
+	}
+	return clamp(threshold, 0.35, 0.95)
 }

--- a/internal/autoSellerService/strategy_config.go
+++ b/internal/autoSellerService/strategy_config.go
@@ -12,14 +12,17 @@ type StrategyConfig struct {
 		NewsWeight   float64 `mapstructure:"newsWeight"`
 		VolumeWeight float64 `mapstructure:"volumeWeight"`
 		FlowWeight   float64 `mapstructure:"flowWeight"`
+		TrendWeight  float64 `mapstructure:"trendWeight"`
 	} `mapstructure:"watchlist"`
 	Entry struct {
-		ThresholdScore  float64 `mapstructure:"thresholdScore"`
-		TechnicalWeight float64 `mapstructure:"technicalWeight"`
-		VolumeWeight    float64 `mapstructure:"volumeWeight"`
-		FlowWeight      float64 `mapstructure:"flowWeight"`
-		MarketWeight    float64 `mapstructure:"marketWeight"`
-		NewsWeight      float64 `mapstructure:"newsWeight"`
+		ThresholdScore            float64 `mapstructure:"thresholdScore"`
+		TechnicalWeight           float64 `mapstructure:"technicalWeight"`
+		VolumeWeight              float64 `mapstructure:"volumeWeight"`
+		FlowWeight                float64 `mapstructure:"flowWeight"`
+		MarketWeight              float64 `mapstructure:"marketWeight"`
+		NewsWeight                float64 `mapstructure:"newsWeight"`
+		TradeTrendWeight          float64 `mapstructure:"tradeTrendWeight"`
+		AggressiveThresholdOffset float64 `mapstructure:"aggressiveThresholdOffset"`
 	} `mapstructure:"entry"`
 	Gates struct {
 		MinTurnover       float64 `mapstructure:"minTurnover"`
@@ -53,15 +56,18 @@ func defaultStrategyConfig() StrategyConfig {
 	cfg.Watchlist.MinScore = 0.25
 	cfg.Watchlist.MaxPicks = 10
 	cfg.Watchlist.NewsWeight = 0.2
-	cfg.Watchlist.VolumeWeight = 0.5
-	cfg.Watchlist.FlowWeight = 0.3
+	cfg.Watchlist.VolumeWeight = 0.45
+	cfg.Watchlist.FlowWeight = 0.2
+	cfg.Watchlist.TrendWeight = 0.15
 
 	cfg.Entry.ThresholdScore = 0.5
-	cfg.Entry.TechnicalWeight = 0.35
+	cfg.Entry.TechnicalWeight = 0.3
 	cfg.Entry.VolumeWeight = 0.2
-	cfg.Entry.FlowWeight = 0.2
+	cfg.Entry.FlowWeight = 0.15
 	cfg.Entry.MarketWeight = 0.15
 	cfg.Entry.NewsWeight = 0.1
+	cfg.Entry.TradeTrendWeight = 0.1
+	cfg.Entry.AggressiveThresholdOffset = 0.08
 
 	cfg.Gates.MinTurnover = 300000000
 	cfg.Gates.MaxSpreadBps = 45

--- a/internal/autoSellerService/trade_trend_test.go
+++ b/internal/autoSellerService/trade_trend_test.go
@@ -1,0 +1,35 @@
+package autoSellerService
+
+import "testing"
+
+func TestSummarizeTradeTrend_PositiveMomentum(t *testing.T) {
+	series := []tradeTrendRow{
+		{price: 100, strength: 90, buyBid: 80, selBid: 120, qty: 1000},
+		{price: 101, strength: 95, buyBid: 90, selBid: 110, qty: 1100},
+		{price: 103, strength: 110, buyBid: 130, selBid: 90, qty: 1500},
+		{price: 104, strength: 120, buyBid: 140, selBid: 80, qty: 1600},
+	}
+
+	trend := summarizeTradeTrend(series)
+	if trend.Composite <= 0.6 {
+		t.Fatalf("expected strong composite trend, got %.4f", trend.Composite)
+	}
+	if trend.BuyPressure <= 0.5 {
+		t.Fatalf("expected buy pressure > 0.5, got %.4f", trend.BuyPressure)
+	}
+}
+
+func TestAdjustedEntryThreshold_AggressiveOffset(t *testing.T) {
+	base := 0.5
+	offset := 0.08
+
+	aggressive := adjustedEntryThreshold(base, 0.8, offset)
+	if aggressive != 0.42 {
+		t.Fatalf("expected aggressive threshold 0.42, got %.2f", aggressive)
+	}
+
+	normal := adjustedEntryThreshold(base, 0.7, offset)
+	if normal != base {
+		t.Fatalf("expected unchanged threshold %.2f, got %.2f", base, normal)
+	}
+}

--- a/internal/config/autoJoosik_market_data_fetcher_conf.yml
+++ b/internal/config/autoJoosik_market_data_fetcher_conf.yml
@@ -27,15 +27,18 @@ strategy:
     minScore: 0.25
     maxPicks: 10
     newsWeight: 0.20
-    volumeWeight: 0.50
-    flowWeight: 0.30
+    volumeWeight: 0.45
+    flowWeight: 0.20
+    trendWeight: 0.15
   entry:
     thresholdScore: 0.50
-    technicalWeight: 0.35
+    technicalWeight: 0.30
     volumeWeight: 0.20
-    flowWeight: 0.20
+    flowWeight: 0.15
     marketWeight: 0.15
     newsWeight: 0.10
+    tradeTrendWeight: 0.10
+    aggressiveThresholdOffset: 0.08
   gates:
     minTurnover: 300000000
     maxSpreadBps: 45


### PR DESCRIPTION
### Motivation

- Allow the buy engine to react to short-term tape/flow signals from `tb_trade_info_log` so the system can pursue higher-probability short intraday entries. 
- Make entry behavior adaptive by lowering the entry threshold when recent trade-info shows strong micro-trend momentum. 
- Rebalance watchlist/entry weights to give meaningful influence to trade-info trend while keeping other signals in play.

### Description

- Added a `TradeInfoTrend` model and pipeline in `internal/autoSellerService/data_providers.go` with `LoadTradeInfoTrend` and `summarizeTradeTrend` to compute price momentum, execution-strength delta, buy-pressure and volume acceleration and a `Composite` score. 
- Integrated trend signals into watchlist scoring and entry factors by adding a `trade_trend` factor and including `trend.Composite` in watchlist score computation inside `internal/autoSellerService/decision_runner.go`. 
- Introduced adaptive thresholding via `adjustedEntryThreshold(base, trendComposite, offset)` so a strong `trend.Composite` can reduce the effective entry threshold and the `decideBuyQty` call uses the effective threshold. 
- Extended strategy config with new keys and defaults (`trendWeight`, `tradeTrendWeight`, `aggressiveThresholdOffset`) and adjusted default weights in `internal/autoSellerService/strategy_config.go` and the YAML in `internal/config/autoJoosik_market_data_fetcher_conf.yml`. 
- Added unit tests `internal/autoSellerService/trade_trend_test.go` to validate `summarizeTradeTrend` behavior and `adjustedEntryThreshold` logic.

### Testing

- Ran formatting on modified Go files with `gofmt` to ensure style consistency and it completed successfully. 
- Executed package unit tests with `go test ./internal/autoSellerService` and the tests passed (`ok`). 
- Executed full repository tests with `go test ./...` and they completed successfully (no failing tests and package tests cached where applicable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeb472ab2c8321bc6e5b8b6a33dca0)