### PR TITLE
Add trade trend analysis and adaptive aggressive entry logic

### DIFF
--- a/internal/autoSellerService/data_providers.go
+++ b/internal/autoSellerService/data_providers.go
@@ -3,8 +3,25 @@ package autoSellerService
 import (
 	"autoJoosik-market-data-fetcher/internal/repository"
 	"context"
+	"math"
 	"time"
 )
+
+type TradeInfoTrend struct {
+	PriceMomentum      float64
+	StrengthMomentum   float64
+	BuyPressure        float64
+	VolumeAcceleration float64
+	Composite          float64
+}
+
+type tradeTrendRow struct {
+	price    float64
+	strength float64
+	buyBid   float64
+	selBid   float64
+	qty      float64
+}
 
 type NewsProvider interface {
 	SentimentScore(ctx context.Context, stkCd string) float64
@@ -76,4 +93,103 @@ LIMIT 1
 		return 0
 	}
 	return (currentBalance - startBalance) / startBalance * 100
+}
+
+func LoadTradeInfoTrend(ctx context.Context, db repository.DB, stkCd string, limit int) (TradeInfoTrend, error) {
+	if limit < 12 {
+		limit = 12
+	}
+	rows, err := db.Query(ctx, `
+SELECT cur_prc, cntr_str, pri_buy_bid_unit, pri_sel_bid_unit, cntr_trde_qty
+FROM tb_trade_info_log
+WHERE stk_cd = $1
+ORDER BY tm DESC
+LIMIT $2
+`, stkCd, limit)
+	if err != nil {
+		return TradeInfoTrend{}, err
+	}
+	defer rows.Close()
+
+	series := make([]tradeTrendRow, 0, limit)
+	for rows.Next() {
+		var r tradeTrendRow
+		if err := rows.Scan(&r.price, &r.strength, &r.buyBid, &r.selBid, &r.qty); err != nil {
+			return TradeInfoTrend{}, err
+		}
+		series = append(series, r)
+	}
+	if err := rows.Err(); err != nil {
+		return TradeInfoTrend{}, err
+	}
+	for i, j := 0, len(series)-1; i < j; i, j = i+1, j-1 {
+		series[i], series[j] = series[j], series[i]
+	}
+
+	return summarizeTradeTrend(series), nil
+}
+
+func summarizeTradeTrend(series []tradeTrendRow) TradeInfoTrend {
+	if len(series) < 2 {
+		return TradeInfoTrend{}
+	}
+
+	head := series[:len(series)/2]
+	tail := series[len(series)/2:]
+	first := series[0].price
+	last := series[len(series)-1].price
+	priceMomentum := 0.0
+	if first > 0 {
+		priceMomentum = (last - first) / first
+	}
+	priceScore := clamp((clamp(priceMomentum, -0.02, 0.02)+0.02)/0.04, 0, 1)
+
+	headStrength := 0.0
+	tailStrength := 0.0
+	for _, r := range head {
+		headStrength += r.strength
+	}
+	for _, r := range tail {
+		tailStrength += r.strength
+	}
+	headStrength /= math.Max(float64(len(head)), 1)
+	tailStrength /= math.Max(float64(len(tail)), 1)
+	strengthDelta := tailStrength - headStrength
+	strengthScore := clamp((clamp(strengthDelta, -20, 20)+20)/40, 0, 1)
+
+	buyPressure := 0.5
+	buyTotal := 0.0
+	sellTotal := 0.0
+	for _, r := range series {
+		buyTotal += math.Max(r.buyBid, 0)
+		sellTotal += math.Max(r.selBid, 0)
+	}
+	if buyTotal+sellTotal > 0 {
+		buyPressure = buyTotal / (buyTotal + sellTotal)
+	}
+
+	headQty := 0.0
+	tailQty := 0.0
+	for _, r := range head {
+		headQty += r.qty
+	}
+	for _, r := range tail {
+		tailQty += r.qty
+	}
+	headQty /= math.Max(float64(len(head)), 1)
+	tailQty /= math.Max(float64(len(tail)), 1)
+	volRatio := 1.0
+	if headQty > 0 {
+		volRatio = tailQty / headQty
+	}
+	volumeScore := clamp((clamp(volRatio, 0.5, 2.0)-0.5)/1.5, 0, 1)
+
+	composite := clamp(priceScore*0.35+strengthScore*0.25+buyPressure*0.2+volumeScore*0.2, 0, 1)
+	return TradeInfoTrend{
+		PriceMomentum:      priceScore,
+		StrengthMomentum:   strengthScore,
+		BuyPressure:        buyPressure,
+		VolumeAcceleration: volumeScore,
+		Composite:          composite,
+	}
 }

--- a/internal/autoSellerService/decision_runner.go
+++ b/internal/autoSellerService/decision_runner.go
@@ -63,15 +63,14 @@ func DecideAndExecute(ctx context.Context, pool repository.DB) error {
 	watchPicks := make([]watchCandidate, 0)
 	for _, c := range candidates {
 		candles, _ := LoadRecentCandles(ctx, pool, c.StkCd, 60)
-		ind := BuildIndicators(candles)
 		volumeBurst := volumeBurstScore(candles)
 		flow := flowProvider.NetBuyScore(ctx, c.StkCd)
 		news := newsProvider.SentimentScore(ctx, c.StkCd)
-		score := news*cfg.Watchlist.NewsWeight + volumeBurst*cfg.Watchlist.VolumeWeight + flow*cfg.Watchlist.FlowWeight
+		trend, _ := LoadTradeInfoTrend(ctx, pool, c.StkCd, 20)
+		score := news*cfg.Watchlist.NewsWeight + volumeBurst*cfg.Watchlist.VolumeWeight + flow*cfg.Watchlist.FlowWeight + trend.Composite*cfg.Watchlist.TrendWeight
 		if score >= cfg.Watchlist.MinScore {
 			watchPicks = append(watchPicks, watchCandidate{Candidate: c, Score: score})
 		}
-		_ = ind
 	}
 	watchPicks = topWatchlist(watchPicks, cfg.Watchlist.MaxPicks)
 
@@ -80,6 +79,10 @@ func DecideAndExecute(ctx context.Context, pool repository.DB) error {
 		c := w.Candidate
 		candles, _ := LoadRecentCandles(ctx, pool, c.StkCd, 120)
 		ind := BuildIndicators(candles)
+		volumeSignal := volumeBurstScore(candles)
+		techScore := technicalScore(ind, c.LastPrice)
+		trend, _ := LoadTradeInfoTrend(ctx, pool, c.StkCd, 30)
+		aggressiveSetup := isAggressiveShortTermSetup(trend, volumeSignal, techScore, cfg)
 		dailyPnL := EstimateDailyPnLPercent(ctx, pool, 0)
 		entry := NewEngine()
 		entry.AddGate(SimpleGate{name: "trade_time", fn: func(e EvalContext) GateResult {
@@ -105,7 +108,7 @@ func DecideAndExecute(ctx context.Context, pool repository.DB) error {
 			return GateResult{Pass: true}
 		}})
 		entry.AddGate(SimpleGate{name: "cooldown", fn: func(e EvalContext) GateResult {
-			if e.Now.Sub(e.Candidate.LastBuyTime) < cfg.CooldownDuration() {
+			if !canBypassCooldown(e.Now, e.Candidate.LastBuyTime, cfg.CooldownDuration(), cfg.Gates.AggressiveCooldownFactor, aggressiveSetup) {
 				return GateResult{Pass: false, Reason: "cooldown"}
 			}
 			return GateResult{Pass: true}
@@ -150,11 +153,16 @@ func DecideAndExecute(ctx context.Context, pool repository.DB) error {
 		entry.AddFactor(WeightedFactor{name: "news", weight: cfg.Entry.NewsWeight, factor: func(e EvalContext) float64 {
 			return e.NewsScore
 		}})
+		entry.AddFactor(WeightedFactor{name: "trade_trend", weight: cfg.Entry.TradeTrendWeight, factor: func(EvalContext) float64 {
+			return trend.Composite
+		}})
 
 		evalCtx := EvalContext{Now: time.Now(), Market: market, Candidate: c, Indicators: ind, NewsScore: newsProvider.SentimentScore(ctx, c.StkCd), FlowScore: flowProvider.NetBuyScore(ctx, c.StkCd), VolumeSignal: volumeBurstScore(candles), RecentOrderOpen: hasOpenOrderRecently(ctx, pool, c.StkCd), DailyPnL: dailyPnL, CurrentSpread: 0}
+		evalCtx.VolumeSignal = volumeSignal
+		effectiveThreshold := adjustedEntryThreshold(cfg.Entry.ThresholdScore, trend, volumeSignal, cfg.Entry.AggressiveThresholdOffset, cfg.Entry.AggressiveMaxOffset)
 		pass, score, reasons := entry.Evaluate(evalCtx)
-		if pass && score >= cfg.Entry.ThresholdScore {
-			buyQty := decideBuyQty(score, cfg.Entry.ThresholdScore, cfg.Sizing.MaxOrderQty)
+		if pass && score >= effectiveThreshold {
+			buyQty := decideBuyQty(score, effectiveThreshold, cfg.Sizing.MaxOrderQty)
 			logger.Info("Buy decision", "stkCd", c.StkCd, "score", score, "qty", buyQty, "reasons", strings.Join(reasons, ","))
 			if err := Buy(c.StkCd, buyQty); err != nil {
 				return err
@@ -261,4 +269,38 @@ func lastVolume(candles []OHLCV) float64 {
 		return 0
 	}
 	return candles[len(candles)-1].Volume
+}
+
+func adjustedEntryThreshold(base float64, trend TradeInfoTrend, volumeSignal, offset, maxOffset float64) float64 {
+	thresholdOffset := 0.0
+	if trend.Composite >= 0.75 {
+		thresholdOffset += offset
+	}
+	if trend.Composite >= 0.85 && volumeSignal >= 0.65 {
+		thresholdOffset += offset * 0.5
+	}
+	if trend.BuyPressure >= 0.62 {
+		thresholdOffset += 0.02
+	}
+	thresholdOffset = clamp(thresholdOffset, 0, maxOffset)
+	return clamp(base-thresholdOffset, 0.3, 0.95)
+}
+
+func canBypassCooldown(now, lastBuyTime time.Time, cooldown time.Duration, aggressiveFactor float64, aggressiveSetup bool) bool {
+	elapsed := now.Sub(lastBuyTime)
+	if elapsed >= cooldown {
+		return true
+	}
+	if !aggressiveSetup {
+		return false
+	}
+	minCooldown := time.Duration(float64(cooldown) * clamp(aggressiveFactor, 0.1, 1.0))
+	return elapsed >= minCooldown
+}
+
+func isAggressiveShortTermSetup(trend TradeInfoTrend, volumeSignal, technical float64, cfg StrategyConfig) bool {
+	return trend.Composite >= cfg.Entry.AggressiveTrendFloor &&
+		trend.BuyPressure >= cfg.Entry.AggressiveBuyPressureFloor &&
+		volumeSignal >= cfg.Entry.AggressiveVolumeFloor &&
+		technical >= 0.5
 }

--- a/internal/autoSellerService/strategy_config.go
+++ b/internal/autoSellerService/strategy_config.go
@@ -12,23 +12,31 @@ type StrategyConfig struct {
 		NewsWeight   float64 `mapstructure:"newsWeight"`
 		VolumeWeight float64 `mapstructure:"volumeWeight"`
 		FlowWeight   float64 `mapstructure:"flowWeight"`
+		TrendWeight  float64 `mapstructure:"trendWeight"`
 	} `mapstructure:"watchlist"`
 	Entry struct {
-		ThresholdScore  float64 `mapstructure:"thresholdScore"`
-		TechnicalWeight float64 `mapstructure:"technicalWeight"`
-		VolumeWeight    float64 `mapstructure:"volumeWeight"`
-		FlowWeight      float64 `mapstructure:"flowWeight"`
-		MarketWeight    float64 `mapstructure:"marketWeight"`
-		NewsWeight      float64 `mapstructure:"newsWeight"`
+		ThresholdScore             float64 `mapstructure:"thresholdScore"`
+		TechnicalWeight            float64 `mapstructure:"technicalWeight"`
+		VolumeWeight               float64 `mapstructure:"volumeWeight"`
+		FlowWeight                 float64 `mapstructure:"flowWeight"`
+		MarketWeight               float64 `mapstructure:"marketWeight"`
+		NewsWeight                 float64 `mapstructure:"newsWeight"`
+		TradeTrendWeight           float64 `mapstructure:"tradeTrendWeight"`
+		AggressiveThresholdOffset  float64 `mapstructure:"aggressiveThresholdOffset"`
+		AggressiveMaxOffset        float64 `mapstructure:"aggressiveMaxOffset"`
+		AggressiveTrendFloor       float64 `mapstructure:"aggressiveTrendFloor"`
+		AggressiveBuyPressureFloor float64 `mapstructure:"aggressiveBuyPressureFloor"`
+		AggressiveVolumeFloor      float64 `mapstructure:"aggressiveVolumeFloor"`
 	} `mapstructure:"entry"`
 	Gates struct {
-		MinTurnover       float64 `mapstructure:"minTurnover"`
-		MaxSpreadBps      float64 `mapstructure:"maxSpreadBps"`
-		CooldownMinutes   int     `mapstructure:"cooldownMinutes"`
-		MaxHoldingCount   int     `mapstructure:"maxHoldingCount"`
-		MaxPositionPct    float64 `mapstructure:"maxPositionPct"`
-		DailyLossLimitPct float64 `mapstructure:"dailyLossLimitPct"`
-		CrashFilterPct    float64 `mapstructure:"crashFilterPct"`
+		MinTurnover              float64 `mapstructure:"minTurnover"`
+		MaxSpreadBps             float64 `mapstructure:"maxSpreadBps"`
+		CooldownMinutes          int     `mapstructure:"cooldownMinutes"`
+		AggressiveCooldownFactor float64 `mapstructure:"aggressiveCooldownFactor"`
+		MaxHoldingCount          int     `mapstructure:"maxHoldingCount"`
+		MaxPositionPct           float64 `mapstructure:"maxPositionPct"`
+		DailyLossLimitPct        float64 `mapstructure:"dailyLossLimitPct"`
+		CrashFilterPct           float64 `mapstructure:"crashFilterPct"`
 	} `mapstructure:"gates"`
 	Risk struct {
 		FixedStopLossPct   float64 `mapstructure:"fixedStopLossPct"`
@@ -53,19 +61,27 @@ func defaultStrategyConfig() StrategyConfig {
 	cfg.Watchlist.MinScore = 0.25
 	cfg.Watchlist.MaxPicks = 10
 	cfg.Watchlist.NewsWeight = 0.2
-	cfg.Watchlist.VolumeWeight = 0.5
-	cfg.Watchlist.FlowWeight = 0.3
+	cfg.Watchlist.VolumeWeight = 0.45
+	cfg.Watchlist.FlowWeight = 0.2
+	cfg.Watchlist.TrendWeight = 0.15
 
 	cfg.Entry.ThresholdScore = 0.5
-	cfg.Entry.TechnicalWeight = 0.35
+	cfg.Entry.TechnicalWeight = 0.3
 	cfg.Entry.VolumeWeight = 0.2
-	cfg.Entry.FlowWeight = 0.2
+	cfg.Entry.FlowWeight = 0.15
 	cfg.Entry.MarketWeight = 0.15
 	cfg.Entry.NewsWeight = 0.1
+	cfg.Entry.TradeTrendWeight = 0.1
+	cfg.Entry.AggressiveThresholdOffset = 0.08
+	cfg.Entry.AggressiveMaxOffset = 0.12
+	cfg.Entry.AggressiveTrendFloor = 0.72
+	cfg.Entry.AggressiveBuyPressureFloor = 0.58
+	cfg.Entry.AggressiveVolumeFloor = 0.45
 
 	cfg.Gates.MinTurnover = 300000000
 	cfg.Gates.MaxSpreadBps = 45
 	cfg.Gates.CooldownMinutes = 10
+	cfg.Gates.AggressiveCooldownFactor = 0.35
 	cfg.Gates.MaxHoldingCount = 10
 	cfg.Gates.MaxPositionPct = 0.2
 	cfg.Gates.DailyLossLimitPct = -4

--- a/internal/autoSellerService/trade_trend_test.go
+++ b/internal/autoSellerService/trade_trend_test.go
@@ -1,0 +1,54 @@
+package autoSellerService
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSummarizeTradeTrend_PositiveMomentum(t *testing.T) {
+	series := []tradeTrendRow{
+		{price: 100, strength: 90, buyBid: 80, selBid: 120, qty: 1000},
+		{price: 101, strength: 95, buyBid: 90, selBid: 110, qty: 1100},
+		{price: 103, strength: 110, buyBid: 130, selBid: 90, qty: 1500},
+		{price: 104, strength: 120, buyBid: 140, selBid: 80, qty: 1600},
+	}
+
+	trend := summarizeTradeTrend(series)
+	if trend.Composite <= 0.6 {
+		t.Fatalf("expected strong composite trend, got %.4f", trend.Composite)
+	}
+	if trend.BuyPressure <= 0.5 {
+		t.Fatalf("expected buy pressure > 0.5, got %.4f", trend.BuyPressure)
+	}
+}
+
+func TestAdjustedEntryThreshold_AggressiveOffset(t *testing.T) {
+	base := 0.5
+	offset := 0.08
+	maxOffset := 0.12
+	strongTrend := TradeInfoTrend{Composite: 0.9, BuyPressure: 0.65}
+
+	aggressive := adjustedEntryThreshold(base, strongTrend, 0.7, offset, maxOffset)
+	if aggressive != 0.38 {
+		t.Fatalf("expected aggressive threshold 0.38, got %.2f", aggressive)
+	}
+
+	normal := adjustedEntryThreshold(base, TradeInfoTrend{Composite: 0.7, BuyPressure: 0.55}, 0.4, offset, maxOffset)
+	if normal != base {
+		t.Fatalf("expected unchanged threshold %.2f, got %.2f", base, normal)
+	}
+}
+
+func TestCanBypassCooldown_AggressiveSetup(t *testing.T) {
+	now := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	lastBuy := now.Add(-4 * time.Minute)
+	cooldown := 10 * time.Minute
+
+	if !canBypassCooldown(now, lastBuy, cooldown, 0.35, true) {
+		t.Fatalf("expected cooldown bypass for aggressive setup")
+	}
+
+	if canBypassCooldown(now, lastBuy, cooldown, 0.35, false) {
+		t.Fatalf("expected cooldown not to bypass without aggressive setup")
+	}
+}

--- a/internal/config/autoJoosik_market_data_fetcher_conf.yml
+++ b/internal/config/autoJoosik_market_data_fetcher_conf.yml
@@ -27,19 +27,27 @@ strategy:
     minScore: 0.25
     maxPicks: 10
     newsWeight: 0.20
-    volumeWeight: 0.50
-    flowWeight: 0.30
+    volumeWeight: 0.45
+    flowWeight: 0.20
+    trendWeight: 0.15
   entry:
     thresholdScore: 0.50
-    technicalWeight: 0.35
+    technicalWeight: 0.30
     volumeWeight: 0.20
-    flowWeight: 0.20
+    flowWeight: 0.15
     marketWeight: 0.15
     newsWeight: 0.10
+    tradeTrendWeight: 0.10
+    aggressiveThresholdOffset: 0.08
+    aggressiveMaxOffset: 0.12
+    aggressiveTrendFloor: 0.72
+    aggressiveBuyPressureFloor: 0.58
+    aggressiveVolumeFloor: 0.45
   gates:
     minTurnover: 300000000
     maxSpreadBps: 45
     cooldownMinutes: 10
+    aggressiveCooldownFactor: 0.35
     maxHoldingCount: 10
     maxPositionPct: 0.20
     dailyLossLimitPct: -4.0


### PR DESCRIPTION
### Motivation
- Improve buy/sell decision quality by incorporating micro-level trade signals (from `tb_trade_info_log`) into watchlist scoring and entry evaluation.
- Allow the strategy to identify aggressive short-term setups and adapt cooldowns and entry thresholds to capture high-probability moves.

### Description
- Add `TradeInfoTrend` and `tradeTrendRow` types and implement `LoadTradeInfoTrend` plus `summarizeTradeTrend` to compute price momentum, strength delta, buy pressure, volume acceleration, and a composite score from recent trade logs.
- Integrate trade trend into the watchlist and entry engines by adding the trend composite as a weighted factor and using it to compute an `effectiveThreshold` via `adjustedEntryThreshold` to lower the entry bar on aggressive setups.
- Introduce `canBypassCooldown` and `isAggressiveShortTermSetup` to let qualifying aggressive setups reduce cooldowns, and extend `StrategyConfig` and default values with new weights and aggressive-related parameters and `AggressiveCooldownFactor`.
- Add `trade_trend_test.go` unit tests covering `summarizeTradeTrend`, `adjustedEntryThreshold`, and `canBypassCooldown`, and update the example configuration file with the new config keys.

### Testing
- Added unit tests in `internal/autoSellerService/trade_trend_test.go` exercising trend summarization, threshold adjustment, and cooldown bypass logic, which all pass.
- Ran `go test ./...` to execute the package test suite and there were no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeb472ab2c8321bc6e5b8b6a33dca0)