### PR TITLE
feat: add aggressive short-term momentum entry and sizing

### DIFF
--- a/internal/autoSellerService/decision_runner.go
+++ b/internal/autoSellerService/decision_runner.go
@@ -153,12 +153,16 @@ func DecideAndExecute(ctx context.Context, pool repository.DB) error {
 		entry.AddFactor(WeightedFactor{name: "trade_trend", weight: cfg.Entry.TradeTrendWeight, factor: func(EvalContext) float64 {
 			return trend.Composite
 		}})
+		entry.AddFactor(WeightedFactor{name: "short_term_momentum", weight: cfg.Entry.ShortTermMomentumWeight, factor: func(e EvalContext) float64 {
+			return shortTermMomentumScore(e.Indicators, e.Candidate.LastPrice, trend.Composite, e.VolumeSignal)
+		}})
 
-		evalCtx := EvalContext{Now: time.Now(), Market: market, Candidate: c, Indicators: ind, NewsScore: newsProvider.SentimentScore(ctx, c.StkCd), FlowScore: flowProvider.NetBuyScore(ctx, c.StkCd), VolumeSignal: volumeBurstScore(candles), RecentOrderOpen: hasOpenOrderRecently(ctx, pool, c.StkCd), DailyPnL: dailyPnL, CurrentSpread: 0}
-		effectiveThreshold := adjustedEntryThreshold(cfg.Entry.ThresholdScore, trend.Composite, cfg.Entry.AggressiveThresholdOffset)
+		volumeSignal := volumeBurstScore(candles)
+		evalCtx := EvalContext{Now: time.Now(), Market: market, Candidate: c, Indicators: ind, NewsScore: newsProvider.SentimentScore(ctx, c.StkCd), FlowScore: flowProvider.NetBuyScore(ctx, c.StkCd), VolumeSignal: volumeSignal, RecentOrderOpen: hasOpenOrderRecently(ctx, pool, c.StkCd), DailyPnL: dailyPnL, CurrentSpread: 0}
+		effectiveThreshold := adjustedEntryThreshold(cfg.Entry.ThresholdScore, trend.Composite, volumeSignal, ind, c.LastPrice, cfg.Entry.AggressiveThresholdOffset)
 		pass, score, reasons := entry.Evaluate(evalCtx)
 		if pass && score >= effectiveThreshold {
-			buyQty := decideBuyQty(score, effectiveThreshold, cfg.Sizing.MaxOrderQty)
+			buyQty := aggressiveBuyQty(score, effectiveThreshold, cfg.Sizing.MaxOrderQty, trend.Composite, volumeSignal, ind, c.LastPrice)
 			logger.Info("Buy decision", "stkCd", c.StkCd, "score", score, "qty", buyQty, "reasons", strings.Join(reasons, ","))
 			if err := Buy(c.StkCd, buyQty); err != nil {
 				return err
@@ -267,10 +271,53 @@ func lastVolume(candles []OHLCV) float64 {
 	return candles[len(candles)-1].Volume
 }
 
-func adjustedEntryThreshold(base, trendComposite, offset float64) float64 {
+func shortTermMomentumScore(ind IndicatorSnapshot, price, trendComposite, volumeSignal float64) float64 {
+	score := 0.0
+	if ind.MA5 > ind.MA20 {
+		score += 0.2
+	}
+	if ind.MACD > ind.MACDSignal {
+		score += 0.2
+	}
+	if ind.RSI14 >= 52 && ind.RSI14 <= 78 {
+		score += 0.2
+	}
+	if price >= ind.BBMiddle {
+		score += 0.15
+	}
+	if price >= ind.VWAP {
+		score += 0.15
+	}
+	score += clamp(trendComposite, 0, 1) * 0.05
+	score += clamp(volumeSignal, 0, 1) * 0.05
+	return clamp(score, 0, 1)
+}
+
+func adjustedEntryThreshold(base, trendComposite, volumeSignal float64, ind IndicatorSnapshot, price, offset float64) float64 {
 	threshold := base
 	if trendComposite >= 0.75 {
 		threshold -= offset
 	}
-	return clamp(threshold, 0.35, 0.95)
+	if trendComposite >= 0.85 && volumeSignal >= 0.65 && ind.RSI14 >= 55 && ind.RSI14 <= 78 && price >= ind.BBMiddle {
+		threshold -= offset * 0.5
+	}
+	return clamp(threshold, 0.30, 0.95)
+}
+
+func aggressiveBuyQty(score, threshold float64, maxOrderQty int, trendComposite, volumeSignal float64, ind IndicatorSnapshot, price float64) float64 {
+	baseQty := decideBuyQty(score, threshold, maxOrderQty)
+	if baseQty <= 0 {
+		return baseQty
+	}
+	if trendComposite >= 0.85 && volumeSignal >= 0.7 && shortTermMomentumScore(ind, price, trendComposite, volumeSignal) >= 0.75 {
+		boosted := baseQty * 1.25
+		if boosted > float64(maxOrderQty) {
+			return float64(maxOrderQty)
+		}
+		if boosted < 1 {
+			return 1
+		}
+		return boosted
+	}
+	return baseQty
 }

--- a/internal/autoSellerService/strategy_config.go
+++ b/internal/autoSellerService/strategy_config.go
@@ -22,6 +22,7 @@ type StrategyConfig struct {
 		MarketWeight              float64 `mapstructure:"marketWeight"`
 		NewsWeight                float64 `mapstructure:"newsWeight"`
 		TradeTrendWeight          float64 `mapstructure:"tradeTrendWeight"`
+		ShortTermMomentumWeight   float64 `mapstructure:"shortTermMomentumWeight"`
 		AggressiveThresholdOffset float64 `mapstructure:"aggressiveThresholdOffset"`
 	} `mapstructure:"entry"`
 	Gates struct {
@@ -64,9 +65,10 @@ func defaultStrategyConfig() StrategyConfig {
 	cfg.Entry.TechnicalWeight = 0.3
 	cfg.Entry.VolumeWeight = 0.2
 	cfg.Entry.FlowWeight = 0.15
-	cfg.Entry.MarketWeight = 0.15
+	cfg.Entry.MarketWeight = 0.1
 	cfg.Entry.NewsWeight = 0.1
 	cfg.Entry.TradeTrendWeight = 0.1
+	cfg.Entry.ShortTermMomentumWeight = 0.15
 	cfg.Entry.AggressiveThresholdOffset = 0.08
 
 	cfg.Gates.MinTurnover = 300000000

--- a/internal/autoSellerService/trade_trend_test.go
+++ b/internal/autoSellerService/trade_trend_test.go
@@ -23,13 +23,29 @@ func TestAdjustedEntryThreshold_AggressiveOffset(t *testing.T) {
 	base := 0.5
 	offset := 0.08
 
-	aggressive := adjustedEntryThreshold(base, 0.8, offset)
+	aggressive := adjustedEntryThreshold(base, 0.8, 0.5, IndicatorSnapshot{RSI14: 60, BBMiddle: 100}, 101, offset)
 	if aggressive != 0.42 {
 		t.Fatalf("expected aggressive threshold 0.42, got %.2f", aggressive)
 	}
 
-	normal := adjustedEntryThreshold(base, 0.7, offset)
+	normal := adjustedEntryThreshold(base, 0.7, 0.5, IndicatorSnapshot{RSI14: 50, BBMiddle: 100}, 99, offset)
 	if normal != base {
 		t.Fatalf("expected unchanged threshold %.2f, got %.2f", base, normal)
+	}
+}
+
+func TestAdjustedEntryThreshold_HighMomentumLowersMore(t *testing.T) {
+	base := 0.5
+	offset := 0.08
+	threshold := adjustedEntryThreshold(base, 0.9, 0.7, IndicatorSnapshot{RSI14: 62, BBMiddle: 100}, 102, offset)
+	if threshold != 0.38 {
+		t.Fatalf("expected stronger lowered threshold 0.38, got %.2f", threshold)
+	}
+}
+
+func TestAggressiveBuyQty_BoostedOnStrongMomentum(t *testing.T) {
+	qty := aggressiveBuyQty(0.8, 0.5, 100, 0.9, 0.8, IndicatorSnapshot{MA5: 102, MA20: 100, MACD: 1.2, MACDSignal: 1.0, RSI14: 65, BBMiddle: 100, VWAP: 99}, 103)
+	if qty <= decideBuyQty(0.8, 0.5, 100) {
+		t.Fatalf("expected boosted qty under strong momentum, got %.2f", qty)
 	}
 }

--- a/internal/config/autoJoosik_market_data_fetcher_conf.yml
+++ b/internal/config/autoJoosik_market_data_fetcher_conf.yml
@@ -35,9 +35,10 @@ strategy:
     technicalWeight: 0.30
     volumeWeight: 0.20
     flowWeight: 0.15
-    marketWeight: 0.15
+    marketWeight: 0.10
     newsWeight: 0.10
     tradeTrendWeight: 0.10
+    shortTermMomentumWeight: 0.15
     aggressiveThresholdOffset: 0.08
   gates:
     minTurnover: 300000000


### PR DESCRIPTION
### Motivation
- Allow more aggressive short-term (breakout-style) entries by adding a momentum factor and adapting threshold/sizing when multiple momentum signals align.

### Description
- Added `entry.shortTermMomentumWeight` to `StrategyConfig` and updated `internal/config/autoJoosik_market_data_fetcher_conf.yml` to expose the new weight with a default of `0.15`.
- Introduced a new `short_term_momentum` weighted factor in `internal/autoSellerService/decision_runner.go` and implemented `shortTermMomentumScore` to score MA/MACD/RSI/BB/VWAP + trend/volume context.
- Extended `adjustedEntryThreshold` to consider `trendComposite`, `volumeSignal`, `IndicatorSnapshot` and `price` and lower the entry threshold further on strong momentum/volume/RSI/BB conditions.
- Added `aggressiveBuyQty` which can boost the base buy quantity (up to 25%) when high-conviction short-term conditions are met while preserving the `maxOrderQty` cap, and wired it into the buy decision flow.
- Updated and added tests in `internal/autoSellerService/trade_trend_test.go` to cover the new threshold behavior and aggressive sizing logic.

### Testing
- Ran `go test ./...` and the package tests for `internal/autoSellerService` passed (`ok`); other packages reported no test files. 
- Ran `gofmt -w` on modified files to ensure formatting consistency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01caa69808321bcd4191840d3123e)