### PR TITLE
UpsertVirtualAsset: replace ON CONFLICT with update-then-insert to avoid 42P10 error

### DIFF
--- a/internal/repository/tb_virtual_asset_repository.go
+++ b/internal/repository/tb_virtual_asset_repository.go
@@ -7,104 +7,70 @@ import (
 )
 
 func UpsertVirtualAsset(ctx context.Context, db DB, entity model.TbVirtualAssetEntity) error {
-	_, err := db.Exec(ctx, `
-		INSERT INTO tb_virtual_asset (
-		  user_id, account_id, stk_cd, market, position_side,
-		  qty, available_qty, avg_price, last_price, highest_price,
-		  invested_amount, eval_amount, eval_pl, eval_pl_rate,
-		  today_buy_qty, today_sell_qty,
-		  status, last_eval_at,
-		  created_at, updated_at
-		) VALUES (
-		  $1, $2, $3, $4, $7::text,
-		  $5, $5, $6, $6, $6,
-		  ($5::numeric * $6::numeric),
-		  ($5::numeric * $6::numeric),
-		  0,
-		  0,
-		  CASE WHEN $7::text = 'B' THEN $5 ELSE 0 END,
-		  CASE WHEN $7::text = 'S' THEN $5 ELSE 0 END,
-		  $8, NOW(),
-		  NOW(), NOW()
-		)
-		ON CONFLICT (account_id, stk_cd, market, position_side)
-		DO UPDATE SET
-		  user_id = EXCLUDED.user_id,
-
+	updateResult, err := db.Exec(ctx, `
+		UPDATE tb_virtual_asset
+		SET
+		  user_id = $1,
 		  qty = CASE
-			WHEN $7::text = 'B' THEN tb_virtual_asset.qty + EXCLUDED.qty
-			WHEN $7::text = 'S' THEN GREATEST(tb_virtual_asset.qty - EXCLUDED.qty, 0)
+			WHEN $7::text = 'B' THEN tb_virtual_asset.qty + $5
+			WHEN $7::text = 'S' THEN GREATEST(tb_virtual_asset.qty - $5, 0)
 			ELSE tb_virtual_asset.qty
 		  END,
-
 		  available_qty = CASE
-			WHEN $7::text = 'B' THEN tb_virtual_asset.available_qty + EXCLUDED.qty
-			WHEN $7::text = 'S' THEN GREATEST(tb_virtual_asset.available_qty - EXCLUDED.qty, 0)
+			WHEN $7::text = 'B' THEN tb_virtual_asset.available_qty + $5
+			WHEN $7::text = 'S' THEN GREATEST(tb_virtual_asset.available_qty - $5, 0)
 			ELSE tb_virtual_asset.available_qty
 		  END,
-
 		  invested_amount = CASE
-			WHEN $7::text = 'B' THEN tb_virtual_asset.invested_amount + EXCLUDED.invested_amount
-			WHEN $7::text = 'S' THEN GREATEST(tb_virtual_asset.invested_amount - (tb_virtual_asset.avg_price * EXCLUDED.qty), 0)
+			WHEN $7::text = 'B' THEN tb_virtual_asset.invested_amount + ($5::numeric * $6::numeric)
+			WHEN $7::text = 'S' THEN GREATEST(tb_virtual_asset.invested_amount - (tb_virtual_asset.avg_price * $5), 0)
 			ELSE tb_virtual_asset.invested_amount
 		  END,
-
 		  avg_price = CASE
-			WHEN $7::text = 'B'
-			 AND (tb_virtual_asset.qty + EXCLUDED.qty) > 0
-			  THEN (tb_virtual_asset.invested_amount + EXCLUDED.invested_amount)
-				   / (tb_virtual_asset.qty + EXCLUDED.qty)
-			WHEN $7::text = 'S'
-			 AND (tb_virtual_asset.qty - EXCLUDED.qty) <= 0 THEN 0
+			WHEN $7::text = 'B' AND (tb_virtual_asset.qty + $5) > 0
+			  THEN (tb_virtual_asset.invested_amount + ($5::numeric * $6::numeric)) / (tb_virtual_asset.qty + $5)
+			WHEN $7::text = 'S' AND (tb_virtual_asset.qty - $5) <= 0 THEN 0
 			ELSE tb_virtual_asset.avg_price
 		  END,
-
-		  last_price = EXCLUDED.last_price,
-
-		highest_price = CASE
-		  WHEN EXCLUDED.position_side = 'B'
-		   AND tb_virtual_asset.highest_price < EXCLUDED.avg_price
-			THEN EXCLUDED.avg_price
-		  WHEN EXCLUDED.position_side = 'S'
-			THEN tb_virtual_asset.highest_price
-		  ELSE tb_virtual_asset.avg_price
-		END,
-
-		eval_amount = CASE
-		  WHEN $7::text = 'B' THEN (tb_virtual_asset.qty + EXCLUDED.qty) * EXCLUDED.last_price
-		  WHEN $7::text = 'S' THEN GREATEST(tb_virtual_asset.qty - EXCLUDED.qty, 0) * EXCLUDED.last_price
-		  ELSE tb_virtual_asset.eval_amount
-		END,
-
-		eval_pl = CASE
-		  WHEN $7::text = 'B' THEN ((tb_virtual_asset.qty + EXCLUDED.qty) * EXCLUDED.last_price) - (tb_virtual_asset.invested_amount + EXCLUDED.invested_amount)
-		  WHEN $7::text = 'S' THEN (GREATEST(tb_virtual_asset.qty - EXCLUDED.qty, 0) * EXCLUDED.last_price)
-									  - GREATEST(tb_virtual_asset.invested_amount - (tb_virtual_asset.avg_price * EXCLUDED.qty), 0)
-		  ELSE tb_virtual_asset.eval_pl
-		END,
-
-		eval_pl_rate = CASE
-		  WHEN $7::text = 'B'
-		   AND (tb_virtual_asset.invested_amount + EXCLUDED.invested_amount) > 0
-			THEN ((((tb_virtual_asset.qty + EXCLUDED.qty) * EXCLUDED.last_price) - (tb_virtual_asset.invested_amount + EXCLUDED.invested_amount))
-					 / (tb_virtual_asset.invested_amount + EXCLUDED.invested_amount)) * 100
-		  WHEN $7::text = 'S'
-		   AND GREATEST(tb_virtual_asset.invested_amount - (tb_virtual_asset.avg_price * EXCLUDED.qty), 0) > 0
-			THEN (((GREATEST(tb_virtual_asset.qty - EXCLUDED.qty, 0) * EXCLUDED.last_price)
-					 - GREATEST(tb_virtual_asset.invested_amount - (tb_virtual_asset.avg_price * EXCLUDED.qty), 0))
-					 / GREATEST(tb_virtual_asset.invested_amount - (tb_virtual_asset.avg_price * EXCLUDED.qty), 0)) * 100
-		  ELSE 0
-		END,
-
-		  today_buy_qty  = tb_virtual_asset.today_buy_qty  + EXCLUDED.today_buy_qty,
-		  today_sell_qty = tb_virtual_asset.today_sell_qty + EXCLUDED.today_sell_qty,
-
+		  last_price = $6,
+		  highest_price = CASE
+			WHEN $7::text = 'B' AND tb_virtual_asset.highest_price < $6 THEN $6
+			WHEN $7::text = 'S' THEN tb_virtual_asset.highest_price
+			ELSE tb_virtual_asset.avg_price
+		  END,
+		  eval_amount = CASE
+			WHEN $7::text = 'B' THEN (tb_virtual_asset.qty + $5) * $6
+			WHEN $7::text = 'S' THEN GREATEST(tb_virtual_asset.qty - $5, 0) * $6
+			ELSE tb_virtual_asset.eval_amount
+		  END,
+		  eval_pl = CASE
+			WHEN $7::text = 'B' THEN ((tb_virtual_asset.qty + $5) * $6) - (tb_virtual_asset.invested_amount + ($5::numeric * $6::numeric))
+			WHEN $7::text = 'S' THEN (GREATEST(tb_virtual_asset.qty - $5, 0) * $6)
+				- GREATEST(tb_virtual_asset.invested_amount - (tb_virtual_asset.avg_price * $5), 0)
+			ELSE tb_virtual_asset.eval_pl
+		  END,
+		  eval_pl_rate = CASE
+			WHEN $7::text = 'B' AND (tb_virtual_asset.invested_amount + ($5::numeric * $6::numeric)) > 0
+			  THEN ((((tb_virtual_asset.qty + $5) * $6) - (tb_virtual_asset.invested_amount + ($5::numeric * $6::numeric)))
+				/ (tb_virtual_asset.invested_amount + ($5::numeric * $6::numeric))) * 100
+			WHEN $7::text = 'S' AND GREATEST(tb_virtual_asset.invested_amount - (tb_virtual_asset.avg_price * $5), 0) > 0
+			  THEN (((GREATEST(tb_virtual_asset.qty - $5, 0) * $6)
+				- GREATEST(tb_virtual_asset.invested_amount - (tb_virtual_asset.avg_price * $5), 0))
+				/ GREATEST(tb_virtual_asset.invested_amount - (tb_virtual_asset.avg_price * $5), 0)) * 100
+			ELSE 0
+		  END,
+		  today_buy_qty  = tb_virtual_asset.today_buy_qty + CASE WHEN $7::text = 'B' THEN $5 ELSE 0 END,
+		  today_sell_qty = tb_virtual_asset.today_sell_qty + CASE WHEN $7::text = 'S' THEN $5 ELSE 0 END,
 		  status = CASE
-			WHEN $7::text = 'S' AND GREATEST(tb_virtual_asset.qty - EXCLUDED.qty, 0) = 0 THEN 'CLOSED'
-			ELSE EXCLUDED.status
+			WHEN $7::text = 'S' AND GREATEST(tb_virtual_asset.qty - $5, 0) = 0 THEN 'CLOSED'
+			ELSE $8
 		  END,
 		  last_eval_at = NOW(),
-		  updated_at   = NOW();
+		  updated_at = NOW()
+		WHERE account_id = $2
+		  AND stk_cd = $3
+		  AND market = $4
+		  AND position_side = $7::text;
 		`,
 		entity.UserId,
 		entity.AccountId,
@@ -118,6 +84,43 @@ func UpsertVirtualAsset(ctx context.Context, db DB, entity model.TbVirtualAssetE
 	if err != nil {
 		logger.Error("UpsertVirtualAsset :: error :: ", err.Error())
 		return err
+	}
+
+	if updateResult.RowsAffected() == 0 {
+		_, err = db.Exec(ctx, `
+			INSERT INTO tb_virtual_asset (
+			  user_id, account_id, stk_cd, market, position_side,
+			  qty, available_qty, avg_price, last_price, highest_price,
+			  invested_amount, eval_amount, eval_pl, eval_pl_rate,
+			  today_buy_qty, today_sell_qty,
+			  status, last_eval_at,
+			  created_at, updated_at
+			) VALUES (
+			  $1, $2, $3, $4, $7::text,
+			  $5, $5, $6, $6, $6,
+			  ($5::numeric * $6::numeric),
+			  ($5::numeric * $6::numeric),
+			  0,
+			  0,
+			  CASE WHEN $7::text = 'B' THEN $5 ELSE 0 END,
+			  CASE WHEN $7::text = 'S' THEN $5 ELSE 0 END,
+			  $8, NOW(),
+			  NOW(), NOW()
+			);
+			`,
+			entity.UserId,
+			entity.AccountId,
+			entity.StkCd,
+			entity.Market,
+			entity.Qty,
+			entity.AvgPrice,
+			entity.PositionSide,
+			entity.Status,
+		)
+		if err != nil {
+			logger.Error("UpsertVirtualAsset :: insert error :: ", err.Error())
+			return err
+		}
 	}
 	logger.Debug("UpsertVirtualAsset :: success :: ", "stk_cd", entity.StkCd)
 	return nil


### PR DESCRIPTION
### Motivation
- The `/market/buy` flow failed with `ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification (SQLSTATE 42P10)` because the code relied on `INSERT ... ON CONFLICT (...)` while the DB schema might lack the matching unique constraint. 
- Make virtual-asset upsert resilient to schema differences by avoiding direct dependence on `ON CONFLICT`.

### Description
- Replaced the single `INSERT ... ON CONFLICT (account_id, stk_cd, market, position_side)` statement in `UpsertVirtualAsset` with a two-step flow that first performs an `UPDATE ... WHERE account_id = $2 AND stk_cd = $3 AND market = $4 AND position_side = $7` and then performs an `INSERT` only if `RowsAffected()` is `0`.
- Preserved all existing position/accounting logic (qty, available_qty, invested_amount, avg_price, last_price, highest_price, eval_amount, eval_pl, eval_pl_rate, today_buy_qty/today_sell_qty, status and timestamps) but adapted expressions to use the `UPDATE` parameter values when computing aggregates.
- Added `updateResult.RowsAffected()` check and an `INSERT` fallback to create the row when no existing record matches the identifying keys.
- Kept existing logging and error handling behavior.

### Testing
- Ran `timeout 60s go test ./internal/autoSellerService/...` and the package tests passed (`ok`).
- Ran `timeout 90s go test ./...` and the test run completed successfully (packages without tests reported as such and the tested package passed).
- No test failures were observed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b16bd2b6c8832183037a0df205d385)